### PR TITLE
Use an 'int' status for wait* on Linux

### DIFF
--- a/ttyrec.c
+++ b/ttyrec.c
@@ -205,7 +205,7 @@ doinput()
 void
 finish()
 {
-#if defined(SVR4)
+#if defined(SVR4) || defined(linux)
 	int status;
 #else /* !SVR4 */
 	union wait status;


### PR DESCRIPTION
See https://www.linuxquestions.org/questions/programming-9/union-wait-problem-269024/ for a discussion.

---
This fixes compilation Fedora 26.