### PR TITLE
Declare set_progname in io.h

### DIFF
--- a/io.h
+++ b/io.h
@@ -5,6 +5,7 @@
 
 int     read_header     (FILE *fp, Header *h);
 int     write_header    (FILE *fp, Header *h);
+void    set_progname    (const char *name);
 FILE*   efopen          (const char *path, const char *mode);
 int     edup            (int oldfd);
 int     edup2           (int oldfd, int newfd);


### PR DESCRIPTION
This fixes warnings in ttyplay.c and ttytime.c:
ttyplay.c: In function ‘main’:
ttyplay.c:271:5: warning: implicit declaration of function ‘set_progname’; did you mean ‘sethostname’? [-Wimplicit-function-declaration]
     set_progname(argv[0]);
     ^~~~~~~~~~~~
     sethostname
ttytime.c: In function ‘main’:
ttytime.c:64:5: warning: implicit declaration of function ‘set_progname’ [-Wimplicit-function-declaration]
     set_progname(argv[0]);
     ^~~~~~~~~~~~